### PR TITLE
Add JWT token middleware and configure Swagger

### DIFF
--- a/WebAPI/Middleware/JwtTokenMiddleware.cs
+++ b/WebAPI/Middleware/JwtTokenMiddleware.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Threading.Tasks;
+
+namespace WebAPI.Middleware
+{
+    /// <summary>
+    /// Simple middleware that ensures each request contains a JWT token
+    /// in the Authorization header using the Bearer scheme.
+    /// </summary>
+    public class JwtTokenMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public JwtTokenMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            if (context.Request.Path.StartsWithSegments("/swagger"))
+            {
+                await _next(context);
+                return;
+            }
+
+            var hasToken = context.Request.Headers.TryGetValue("Authorization", out var authHeader)
+                && authHeader.ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase);
+
+            if (!hasToken)
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                await context.Response.WriteAsync("JWT token is missing.");
+                return;
+            }
+
+            await _next(context);
+        }
+    }
+}

--- a/WebAPI/Program.cs
+++ b/WebAPI/Program.cs
@@ -1,20 +1,53 @@
+using Microsoft.OpenApi.Models;
+using WebAPI.Middleware;
+using System;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
 builder.Services.AddControllers();
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "Bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "JWT Authorization header using the Bearer scheme."
+    });
+
+    options.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+});
 
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-    app.MapOpenApi();
+    app.UseSwagger();
+    app.UseSwaggerUI();
 }
 
 app.UseHttpsRedirection();
+
+app.UseMiddleware<JwtTokenMiddleware>();
 
 app.UseAuthorization();
 

--- a/WebAPI/WebAPI.csproj
+++ b/WebAPI/WebAPI.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add middleware that checks for a Bearer JWT token on every request and allows access to Swagger endpoints without tokens
- integrate Swagger UI and JWT security scheme

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68935918c5d4832a9f4cd19070cc653d