### PR TITLE
Add log ID middleware for WebAPI and GraphQL

### DIFF
--- a/GraphQL/GraphQL/Query.cs
+++ b/GraphQL/GraphQL/Query.cs
@@ -1,4 +1,6 @@
 using Models;
+using HotChocolate;
+using Microsoft.Extensions.Logging;
 
 namespace GraphQL;
 
@@ -12,6 +14,9 @@ public class Query
     /// <summary>
     /// 取回目前所有訊息
     /// </summary>
-    public IEnumerable<Models.Message> GetMessages()
-        => MessageStore.Messages;
+    public IEnumerable<Models.Message> GetMessages([Service] ILogger<Query> logger)
+    {
+        logger.LogInformation("Fetching messages");
+        return MessageStore.Messages;
+    }
 }

--- a/GraphQL/Middleware/LogIdMiddleware.cs
+++ b/GraphQL/Middleware/LogIdMiddleware.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace GraphQL.Middleware;
+
+public class LogIdMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<LogIdMiddleware> _logger;
+
+    public LogIdMiddleware(RequestDelegate next, ILogger<LogIdMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var logId = Guid.NewGuid().ToString();
+        using (_logger.BeginScope(new Dictionary<string, object> { ["LogId"] = logId }))
+        {
+            context.Response.Headers["X-Log-Id"] = logId;
+            _logger.LogInformation("Handling request {Method} {Path}", context.Request.Method, context.Request.Path);
+            await _next(context);
+            _logger.LogInformation("Finished handling request.");
+        }
+    }
+}

--- a/GraphQL/Program.cs
+++ b/GraphQL/Program.cs
@@ -1,6 +1,7 @@
 ﻿using GraphQL;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using GraphQL.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -12,6 +13,7 @@ builder.Services
     .AddInMemorySubscriptions(); // 換成 AddRedisSubscriptions() … 亦可
 
 var app = builder.Build();
+app.UseMiddleware<LogIdMiddleware>();
 app.UseWebSockets(); // WebSocket 必備
 app.MapGraphQL(); // 預設路徑 /graphql
 app.Run();

--- a/WebAPI/Controllers/WeatherForecastController.cs
+++ b/WebAPI/Controllers/WeatherForecastController.cs
@@ -21,6 +21,7 @@ public class WeatherForecastController : ControllerBase
     [HttpGet(Name = "GetWeatherForecast")]
     public IEnumerable<WeatherForecast> Get()
     {
+        _logger.LogInformation("Generating weather forecast");
         return Enumerable.Range(1, 5).Select(index => new WeatherForecast
         {
             Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),

--- a/WebAPI/Middleware/LogIdMiddleware.cs
+++ b/WebAPI/Middleware/LogIdMiddleware.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WebAPI.Middleware;
+
+public class LogIdMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<LogIdMiddleware> _logger;
+
+    public LogIdMiddleware(RequestDelegate next, ILogger<LogIdMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var logId = Guid.NewGuid().ToString();
+        using (_logger.BeginScope(new Dictionary<string, object> { ["LogId"] = logId }))
+        {
+            context.Response.Headers["X-Log-Id"] = logId;
+            _logger.LogInformation("Handling request {Method} {Path}", context.Request.Method, context.Request.Path);
+            await _next(context);
+            _logger.LogInformation("Finished handling request.");
+        }
+    }
+}

--- a/WebAPI/Program.cs
+++ b/WebAPI/Program.cs
@@ -47,6 +47,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+app.UseMiddleware<LogIdMiddleware>();
 app.UseMiddleware<JwtTokenMiddleware>();
 
 app.UseAuthorization();


### PR DESCRIPTION
## Summary
- add middleware generating a unique log ID for each request and logging start/end
- register the log ID middleware for WebAPI and GraphQL; demonstrate logging in controllers/resolvers

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden, repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689cc86cf830832a88d2bbec746e02e1