### PR TITLE
fix: adjust service Dockerfiles for root build

### DIFF
--- a/src/Services/Service.GraphQL/Dockerfile
+++ b/src/Services/Service.GraphQL/Dockerfile
@@ -4,16 +4,16 @@ WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
-WORKDIR /src
-COPY ["Service.GraphQL/Service.GraphQL.csproj", "Service.GraphQL/"]
-RUN dotnet restore "Service.GraphQL/Service.GraphQL.csproj"
+WORKDIR /workspace
+COPY ["src/Services/Service.GraphQL/Service.GraphQL.csproj", "src/Services/Service.GraphQL/"]
+RUN dotnet restore "src/Services/Service.GraphQL/Service.GraphQL.csproj"
 COPY . .
-WORKDIR "/src/Service.GraphQL"
-RUN dotnet build "./Service.GraphQL.csproj" -c $BUILD_CONFIGURATION -o /app/build
+WORKDIR "/workspace/src/Services/Service.GraphQL"
+RUN dotnet build "Service.GraphQL.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./Service.GraphQL.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "Service.GraphQL.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
 WORKDIR /app

--- a/src/Services/Service.WebAPI/Dockerfile
+++ b/src/Services/Service.WebAPI/Dockerfile
@@ -1,10 +1,11 @@
 # Build and publish the Service.WebAPI project
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
-WORKDIR /src
-COPY ["Service.WebAPI/Service.WebAPI.csproj", "Service.WebAPI/"]
-RUN dotnet restore "Service.WebAPI/Service.WebAPI.csproj"
+WORKDIR /workspace
+COPY ["src/Services/Service.WebAPI/Service.WebAPI.csproj", "src/Services/Service.WebAPI/"]
+COPY ["src/Librarys/Library.Core/Library.Core.csproj", "src/Librarys/Library.Core/"]
+RUN dotnet restore "src/Services/Service.WebAPI/Service.WebAPI.csproj"
 COPY . .
-WORKDIR "/src/Service.WebAPI"
+WORKDIR "/workspace/src/Services/Service.WebAPI"
 RUN dotnet publish "Service.WebAPI.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final


### PR DESCRIPTION
## Summary
- allow WebAPI and GraphQL Dockerfiles to be built from the solution root
- include Library.Core project when restoring WebAPI dependencies

## Testing
- `dotnet build Solution.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b7c931e4832aab7fcb1a6a9834ca