### PR TITLE
Add InfoHelper library with startup country cache

### DIFF
--- a/Solution.sln
+++ b/Solution.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Service.WebAPI", "src\Servi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Library.Database", "src\Librarys\Library.Database\Library.Database.csproj", "{BC860009-990D-4BD4-AD72-AAFCE54F9A5E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Library.InfoHelper", "src\Librarys\Library.InfoHelper\Library.InfoHelper.csproj", "{4462C775-5964-49AE-AC07-519CF612BB53}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -80,6 +82,19 @@ Global
 		{BC860009-990D-4BD4-AD72-AAFCE54F9A5E}.Release|x64.Build.0 = Release|Any CPU
 		{BC860009-990D-4BD4-AD72-AAFCE54F9A5E}.Release|x86.ActiveCfg = Release|Any CPU
 		{BC860009-990D-4BD4-AD72-AAFCE54F9A5E}.Release|x86.Build.0 = Release|Any CPU
+                {4462C775-5964-49AE-AC07-519CF612BB53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {4462C775-5964-49AE-AC07-519CF612BB53}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {4462C775-5964-49AE-AC07-519CF612BB53}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {4462C775-5964-49AE-AC07-519CF612BB53}.Debug|x64.Build.0 = Debug|Any CPU
+                {4462C775-5964-49AE-AC07-519CF612BB53}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {4462C775-5964-49AE-AC07-519CF612BB53}.Debug|x86.Build.0 = Debug|Any CPU
+                {4462C775-5964-49AE-AC07-519CF612BB53}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {4462C775-5964-49AE-AC07-519CF612BB53}.Release|Any CPU.Build.0 = Release|Any CPU
+                {4462C775-5964-49AE-AC07-519CF612BB53}.Release|x64.ActiveCfg = Release|Any CPU
+                {4462C775-5964-49AE-AC07-519CF612BB53}.Release|x64.Build.0 = Release|Any CPU
+                {4462C775-5964-49AE-AC07-519CF612BB53}.Release|x86.ActiveCfg = Release|Any CPU
+                {4462C775-5964-49AE-AC07-519CF612BB53}.Release|x86.Build.0 = Release|Any CPU
+
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Librarys/Library.InfoHelper/CountryCache.cs
+++ b/src/Librarys/Library.InfoHelper/CountryCache.cs
@@ -1,0 +1,15 @@
+using Library.Database.Models.Public;
+
+namespace Library.InfoHelper;
+
+public static class CountryCache
+{
+    private static List<Country> _countries = new();
+
+    public static IReadOnlyList<Country> Countries => _countries;
+
+    internal static void SetCountries(List<Country> countries)
+    {
+        _countries = countries;
+    }
+}

--- a/src/Librarys/Library.InfoHelper/CountryCacheHostedService.cs
+++ b/src/Librarys/Library.InfoHelper/CountryCacheHostedService.cs
@@ -1,0 +1,27 @@
+using Library.Database.Contexts.Public;
+using Library.Database.Models.Public;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Library.InfoHelper;
+
+public class CountryCacheHostedService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<CountryCacheHostedService> logger
+) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        using IServiceScope scope = scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<PublicDbContext>();
+        List<Country> countries = await dbContext.Countries
+            .OrderBy(x => x.CountryName)
+            .ToListAsync(cancellationToken);
+        CountryCache.SetCountries(countries);
+        logger.LogInformation("Loaded {Count} countries into cache", countries.Count);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Librarys/Library.InfoHelper/InfoHelperServiceCollectionExtensions.cs
+++ b/src/Librarys/Library.InfoHelper/InfoHelperServiceCollectionExtensions.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Library.InfoHelper;
+
+public static class InfoHelperServiceCollectionExtensions
+{
+    public static IServiceCollection AddInfoHelper(this IServiceCollection services)
+    {
+        services.AddHostedService<CountryCacheHostedService>();
+        return services;
+    }
+}

--- a/src/Librarys/Library.InfoHelper/Library.InfoHelper.csproj
+++ b/src/Librarys/Library.InfoHelper/Library.InfoHelper.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\\Library.Database\\Library.Database.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Services/Service.WebAPI/Program.cs
+++ b/src/Services/Service.WebAPI/Program.cs
@@ -2,6 +2,7 @@ using Library.Core.Logging;
 using Library.Core.Middlewares;
 using Library.Core.Time;
 using Library.Database.Contexts.Public;
+using Library.InfoHelper;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -35,6 +36,7 @@ namespace Service.WebAPI
             builder.Services.AddScoped<ICalcService, CalcService>();
             builder.Services.AddScoped<ICountriesService, CountriesService>();
             builder.Services.AddTimezoneService();
+            builder.Services.AddInfoHelper();
         }
 
         private static void ConfigSwagger(WebApplicationBuilder builder)

--- a/src/Services/Service.WebAPI/Service.WebAPI.csproj
+++ b/src/Services/Service.WebAPI/Service.WebAPI.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Librarys\Library.Core\Library.Core.csproj" />
     <ProjectReference Include="..\..\Librarys\Library.Database\Library.Database.csproj" />
+    <ProjectReference Include="..\..\Librarys\Library.InfoHelper\Library.InfoHelper.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Services/Service.WebAPI/Services/Countries/CountriesService.cs
+++ b/src/Services/Service.WebAPI/Services/Countries/CountriesService.cs
@@ -1,30 +1,26 @@
 using Library.Core.Results;
 using Library.Core.Time.Models;
 using Library.Core.Time.Services;
-using Library.Database.Contexts.Public;
 using Library.Database.Models.Public;
-
-using Microsoft.EntityFrameworkCore;
+using Library.InfoHelper;
 
 using Service.WebAPI.Models.Countries;
 
 namespace Service.WebAPI.Services.Countries;
 
 public class CountriesService(
-    PublicDbContext dbContext,
     ILogger<CountriesService> logger,
     ITimezoneService timezoneService
 ) : ICountriesService
 {
-    public async Task<Result<List<Country>>> GetCountriesAsync()
+    public Task<Result<List<Country>>> GetCountriesAsync()
     {
         try
         {
-            List<Country> data = await dbContext.Countries
+            List<Country> data = CountryCache.Countries
                 .OrderBy(x => x.CountryName)
-                .ToListAsync();
-
-            return Result<List<Country>>.Ok(data);
+                .ToList();
+            return Task.FromResult(Result<List<Country>>.Ok(data));
         }
         catch (Exception ex)
         {
@@ -33,40 +29,40 @@ public class CountriesService(
         }
     }
 
-    public async Task<Result<Country?>> GetCountryByIdAsync(int id)
+    public Task<Result<Country?>> GetCountryByIdAsync(int id)
     {
-        Country? item = await dbContext.Countries
-            .FirstOrDefaultAsync(x => x.Id == id);
+        Country? item = CountryCache.Countries
+            .FirstOrDefault(x => x.Id == id);
 
         if (item == null)
         {
             return Result<Country?>.Fail("Country not found");
         }
 
-        return Result<Country?>.Ok(item);
+        return Task.FromResult(Result<Country?>.Ok(item));
     }
 
-    public async Task<Result<LocalTimeResponse>> GetLocalTimeAsync(string countryName)
+    public Task<Result<LocalTimeResponse>> GetLocalTimeAsync(string countryName)
     {
         try
         {
-            Country? country = await dbContext.Countries
-                .FirstOrDefaultAsync(x => x.CountryName.ToLower() == countryName.ToLower());
+            Country? country = CountryCache.Countries
+                .FirstOrDefault(x => x.CountryName.ToLower() == countryName.ToLower());
 
             if (country == null || string.IsNullOrEmpty(country.Timezone))
             {
-                return Result<LocalTimeResponse>.Fail("Country not found");
+                return Task.FromResult(Result<LocalTimeResponse>.Fail("Country not found"));
             }
 
             TimezoneComputationResult tzResult = timezoneService.ComputeLocalTime(country.Timezone);
 
-            return Result<LocalTimeResponse>.Ok(new LocalTimeResponse
+            return Task.FromResult(Result<LocalTimeResponse>.Ok(new LocalTimeResponse
             {
                 CountryName = country.CountryName,
                 Timezone = country.Timezone,
                 LocalTime = tzResult.LocalTime,
                 UtcOffset = tzResult.UtcOffset
-            });
+            }));
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- add Library.InfoHelper project with hosted service to preload countries
- load country cache on WebAPI startup and serve countries from memory
- wire up info helper library into WebAPI project

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af316d32a0832abde9e916744e9523