### PR TITLE
Add InfoHelper library for cached country data

### DIFF
--- a/Solution.sln
+++ b/Solution.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Service.WebAPI", "src\Servi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Library.Database", "src\Librarys\Library.Database\Library.Database.csproj", "{BC860009-990D-4BD4-AD72-AAFCE54F9A5E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Library.InfoHelper", "src\Librarys\Library.InfoHelper\Library.InfoHelper.csproj", "{EE34E32A-8CE3-43B4-A470-5E2913339246}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -80,6 +82,18 @@ Global
 		{BC860009-990D-4BD4-AD72-AAFCE54F9A5E}.Release|x64.Build.0 = Release|Any CPU
 		{BC860009-990D-4BD4-AD72-AAFCE54F9A5E}.Release|x86.ActiveCfg = Release|Any CPU
 		{BC860009-990D-4BD4-AD72-AAFCE54F9A5E}.Release|x86.Build.0 = Release|Any CPU
+                {EE34E32A-8CE3-43B4-A470-5E2913339246}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {EE34E32A-8CE3-43B4-A470-5E2913339246}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {EE34E32A-8CE3-43B4-A470-5E2913339246}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {EE34E32A-8CE3-43B4-A470-5E2913339246}.Debug|x64.Build.0 = Debug|Any CPU
+                {EE34E32A-8CE3-43B4-A470-5E2913339246}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {EE34E32A-8CE3-43B4-A470-5E2913339246}.Debug|x86.Build.0 = Debug|Any CPU
+                {EE34E32A-8CE3-43B4-A470-5E2913339246}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {EE34E32A-8CE3-43B4-A470-5E2913339246}.Release|Any CPU.Build.0 = Release|Any CPU
+                {EE34E32A-8CE3-43B4-A470-5E2913339246}.Release|x64.ActiveCfg = Release|Any CPU
+                {EE34E32A-8CE3-43B4-A470-5E2913339246}.Release|x64.Build.0 = Release|Any CPU
+                {EE34E32A-8CE3-43B4-A470-5E2913339246}.Release|x86.ActiveCfg = Release|Any CPU
+                {EE34E32A-8CE3-43B4-A470-5E2913339246}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Librarys/Library.InfoHelper/CountryCache.cs
+++ b/src/Librarys/Library.InfoHelper/CountryCache.cs
@@ -1,0 +1,22 @@
+using Library.Database.Contexts.Public;
+using Library.Database.Models.Public;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Library.InfoHelper;
+
+public static class CountryCache
+{
+    private static List<Country> _countries = [];
+
+    public static IReadOnlyList<Country> Countries => _countries;
+
+    public static async Task RefreshAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken = default)
+    {
+        using IServiceScope scope = serviceProvider.CreateScope();
+        PublicDbContext dbContext = scope.ServiceProvider.GetRequiredService<PublicDbContext>();
+        _countries = await dbContext.Countries
+            .OrderBy(x => x.CountryName)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/Librarys/Library.InfoHelper/InfoHostedService.cs
+++ b/src/Librarys/Library.InfoHelper/InfoHostedService.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Library.InfoHelper;
+
+public class InfoHostedService(IServiceProvider serviceProvider, ILogger<InfoHostedService> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await CountryCache.RefreshAsync(serviceProvider, cancellationToken);
+        logger.LogInformation("Country cache initialized with {Count} items", CountryCache.Countries.Count);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Librarys/Library.InfoHelper/Library.InfoHelper.csproj
+++ b/src/Librarys/Library.InfoHelper/Library.InfoHelper.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Library.Database\Library.Database.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+  </ItemGroup>
+
+</Project>

--- a/src/Librarys/Library.InfoHelper/ServiceCollectionExtensions.cs
+++ b/src/Librarys/Library.InfoHelper/ServiceCollectionExtensions.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Library.InfoHelper;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddInfoHelper(this IServiceCollection services)
+    {
+        services.AddHostedService<InfoHostedService>();
+        return services;
+    }
+}

--- a/src/Services/Service.WebAPI/Controllers/CountriesController.cs
+++ b/src/Services/Service.WebAPI/Controllers/CountriesController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 
 using Service.WebAPI.Models.Countries;
 using Service.WebAPI.Services.Countries;
+using Library.InfoHelper;
 
 namespace Service.WebAPI.Controllers
 {
@@ -38,6 +39,13 @@ namespace Service.WebAPI.Controllers
             return result.Message == "Country not found"
                 ? NotFound(result)
                 : StatusCode(StatusCodes.Status500InternalServerError, result);
+        }
+
+        [HttpPost("refresh")]
+        public async Task<IActionResult> Refresh()
+        {
+            await CountryCache.RefreshAsync(HttpContext.RequestServices);
+            return Ok(Result<string>.Ok("Cache refreshed"));
         }
     }
 }

--- a/src/Services/Service.WebAPI/Program.cs
+++ b/src/Services/Service.WebAPI/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 
 using Service.WebAPI.Services.Calc;
 using Service.WebAPI.Services.Countries;
+using Library.InfoHelper;
 
 namespace Service.WebAPI
 {
@@ -35,6 +36,7 @@ namespace Service.WebAPI
             builder.Services.AddScoped<ICalcService, CalcService>();
             builder.Services.AddScoped<ICountriesService, CountriesService>();
             builder.Services.AddTimezoneService();
+            builder.Services.AddInfoHelper();
         }
 
         private static void ConfigSwagger(WebApplicationBuilder builder)

--- a/src/Services/Service.WebAPI/Service.WebAPI.csproj
+++ b/src/Services/Service.WebAPI/Service.WebAPI.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Librarys\Library.Core\Library.Core.csproj" />
     <ProjectReference Include="..\..\Librarys\Library.Database\Library.Database.csproj" />
+    <ProjectReference Include="..\..\Librarys\Library.InfoHelper\Library.InfoHelper.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Services/Service.WebAPI/Services/Countries/CountriesService.cs
+++ b/src/Services/Service.WebAPI/Services/Countries/CountriesService.cs
@@ -1,77 +1,54 @@
 using Library.Core.Results;
 using Library.Core.Time.Models;
 using Library.Core.Time.Services;
-using Library.Database.Contexts.Public;
 using Library.Database.Models.Public;
-
-using Microsoft.EntityFrameworkCore;
+using Library.InfoHelper;
 
 using Service.WebAPI.Models.Countries;
 
 namespace Service.WebAPI.Services.Countries;
 
 public class CountriesService(
-    PublicDbContext dbContext,
-    ILogger<CountriesService> logger,
     ITimezoneService timezoneService
 ) : ICountriesService
 {
-    public async Task<Result<List<Country>>> GetCountriesAsync()
+    public Task<Result<List<Country>>> GetCountriesAsync()
     {
-        try
-        {
-            List<Country> data = await dbContext.Countries
-                .OrderBy(x => x.CountryName)
-                .ToListAsync();
+        List<Country> data = CountryCache.Countries
+            .OrderBy(x => x.CountryName)
+            .ToList();
 
-            return Result<List<Country>>.Ok(data);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "CountriesService.GetCountriesAsync Error");
-            throw;
-        }
+        return Task.FromResult(Result<List<Country>>.Ok(data));
     }
 
-    public async Task<Result<Country?>> GetCountryByIdAsync(int id)
+    public Task<Result<Country?>> GetCountryByIdAsync(int id)
     {
-        Country? item = await dbContext.Countries
-            .FirstOrDefaultAsync(x => x.Id == id);
-
-        if (item == null)
-        {
-            return Result<Country?>.Fail("Country not found");
-        }
-
-        return Result<Country?>.Ok(item);
+        Country? item = CountryCache.Countries.FirstOrDefault(x => x.Id == id);
+        return Task.FromResult(item != null
+            ? Result<Country?>.Ok(item)
+            : Result<Country?>.Fail("Country not found"));
     }
 
-    public async Task<Result<LocalTimeResponse>> GetLocalTimeAsync(string countryName)
+    public Task<Result<LocalTimeResponse>> GetLocalTimeAsync(string countryName)
     {
-        try
+        Country? country = CountryCache.Countries
+            .FirstOrDefault(x => string.Equals(x.CountryName, countryName, StringComparison.OrdinalIgnoreCase));
+
+        if (country == null || string.IsNullOrEmpty(country.Timezone))
         {
-            Country? country = await dbContext.Countries
-                .FirstOrDefaultAsync(x => x.CountryName.ToLower() == countryName.ToLower());
-
-            if (country == null || string.IsNullOrEmpty(country.Timezone))
-            {
-                return Result<LocalTimeResponse>.Fail("Country not found");
-            }
-
-            TimezoneComputationResult tzResult = timezoneService.ComputeLocalTime(country.Timezone);
-
-            return Result<LocalTimeResponse>.Ok(new LocalTimeResponse
-            {
-                CountryName = country.CountryName,
-                Timezone = country.Timezone,
-                LocalTime = tzResult.LocalTime,
-                UtcOffset = tzResult.UtcOffset
-            });
+            return Task.FromResult(Result<LocalTimeResponse>.Fail("Country not found"));
         }
-        catch (Exception ex)
+
+        TimezoneComputationResult tzResult = timezoneService.ComputeLocalTime(country.Timezone);
+
+        LocalTimeResponse response = new()
         {
-            logger.LogError(ex, "CountriesService.GetLocalTimeAsync Error");
-            throw;
-        }
+            CountryName = country.CountryName,
+            Timezone = country.Timezone,
+            LocalTime = tzResult.LocalTime,
+            UtcOffset = tzResult.UtcOffset
+        };
+
+        return Task.FromResult(Result<LocalTimeResponse>.Ok(response));
     }
 }


### PR DESCRIPTION
## Summary
- create InfoHelper library with hosted service to cache countries on startup and provide refresh API
- wire WebAPI to use cached countries instead of querying DB per request
- add endpoint to manually refresh country cache

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af3dcfda38832ab08ae0d05a35bb77