### PR TITLE
feat(auth): add basic auth service with JWT

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,17 +13,18 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 # =========================
-# C# code style / formatting
+# C# code style / formatting (Rider/VS 通用)
 # =========================
 [*.cs]
 indent_style = space
 indent_size = 4
+tab_width = 4
 
 # --- Using 相關 ---
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = true
 # C# 10+：建議 file-scoped namespace
-csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_namespace_declarations = file_scoped:warning
 # using 放在最上層（搭配 file-scoped）
 csharp_using_directive_placement = outside_namespace:silent
 
@@ -35,21 +36,20 @@ csharp_indent_braces = false
 csharp_indent_switch_labels = true
 csharp_indent_case_contents = true
 csharp_indent_labels = flush_left
+
+# --- 空白 ---
 csharp_space_after_keywords_in_control_flow_statements = true
 csharp_space_between_method_call_empty_parameter_list_parentheses = false
 csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_around_binary_operators = before_and_after
 
-# --- var 使用規範 ---
-# 1) 型別明顯 → 用 var
-csharp_style_var_when_type_is_apparent = true:suggestion
-# 2) 內建型別 → 用 var（可讀性一致）
-csharp_style_var_for_built_in_types = true:suggestion
-# 3) 其他情況 → 明確型別
-csharp_style_var_elsewhere = false:suggestion
+# --- var 使用規範（嚴格型別）---
+csharp_style_var_when_type_is_apparent = false:warning
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_elsewhere = false:warning
 
-# --- 表達式/語法偏好 ---
+# --- 表達式/語法偏好（保守且通用）---
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
 dotnet_style_prefer_auto_properties = true:suggestion
@@ -59,39 +59,22 @@ dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
 
-# C# 現代語法
+# Expression-bodied（單行時可用）
 csharp_style_expression_bodied_methods = when_on_single_line:suggestion
 csharp_style_expression_bodied_properties = when_on_single_line:suggestion
 csharp_style_expression_bodied_indexers = when_on_single_line:suggestion
 csharp_style_expression_bodied_accessors = when_on_single_line:suggestion
+
+# pattern matching / using
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_prefer_switch_expression = true:suggestion
-csharp_style_prefer_tuple_swap = true:suggestion
-csharp_style_prefer_primary_constructors = false:silent
-csharp_style_prefer_top_level_statements = false:silent
-
-# Lambda / 本機函式
-csharp_style_prefer_local_over_anonymous_function = true:suggestion
-csharp_style_prefer_simple_lambda_expression = true:suggestion
-csharp_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
-csharp_style_parentheses_in_relational_binary_operators = always_for_clarity
-
-# using / Dispose
 csharp_prefer_simple_using_statement = true:suggestion
 
-# 變數/欄位
+# 變數/欄位/存取修飾
 dotnet_style_readonly_field = true:warning
-csharp_prefer_static_local_function = true:suggestion
-
-# record/struct
-dotnet_style_prefer_record_struct = true:suggestion
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+csharp_preferred_modifier_order = public, private, protected, internal, static, readonly, async:suggestion
 
-# Nullable（仍建議在 .csproj 啟用 <Nullable>enable</Nullable>）
-dotnet_style_prefer_simplified_null_check = true:suggestion
-
-# --- 修飾詞與 brace ---
-csharp_preferred_modifier_order = public,private,protected,internal,static,readonly,async:suggestion
+# 成員限定（this. 省略偏好）
 dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_property = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion
@@ -102,32 +85,29 @@ dotnet_style_qualification_for_event = false:suggestion
 # =========================
 # 規則：介面 I 開頭；Private/Protected 欄位 _camelCase；型別/屬性/方法 PascalCase；常數 PascalCase
 
-# 符號規範宣告
+# 符號集合
 dotnet_naming_symbols.interfaces.applicable_kinds = interface
 dotnet_naming_symbols.interfaces.applicable_accessibilities = *
-dotnet_naming_symbols.interfaces.required_modifiers = *
 
 dotnet_naming_symbols.private_fields.applicable_kinds = field
-dotnet_naming_symbols.private_fields.applicable_accessibilities = private,protected,protected_internal,private_protected
-dotnet_naming_symbols.private_fields.required_modifiers = *
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
 
 dotnet_naming_symbols.constants.applicable_kinds = field
 dotnet_naming_symbols.constants.applicable_accessibilities = *
 dotnet_naming_symbols.constants.required_modifiers = const
 
-dotnet_naming_symbols.types_and_members.applicable_kinds = class,struct,enum,property,method,delegate,event
+dotnet_naming_symbols.types_and_members.applicable_kinds = class, struct, enum, property, method, delegate, event
 dotnet_naming_symbols.types_and_members.applicable_accessibilities = *
-dotnet_naming_symbols.types_and_members.required_modifiers = *
 
 # 命名樣式
-dotnet_naming_style.pascal_case.capitalization = PascalCase
-dotnet_naming_style.camel_case.capitalization = camelCase
-dotnet_naming_style.prefix_i.capitalization = PascalCase
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_naming_style.camel_case.capitalization = camel_case
+dotnet_naming_style.prefix_i.capitalization = pascal_case
 dotnet_naming_style.prefix_i.required_prefix = I
-dotnet_naming_style.leading_underscore.capitalization = camelCase
+dotnet_naming_style.leading_underscore.capitalization = camel_case
 dotnet_naming_style.leading_underscore.required_prefix = _
 
-# 套用規則
+# 規則
 dotnet_naming_rule.interfaces_should_be_prefixed_with_i.symbols = interfaces
 dotnet_naming_rule.interfaces_should_be_prefixed_with_i.style = prefix_i
 dotnet_naming_rule.interfaces_should_be_prefixed_with_i.severity = suggestion
@@ -145,24 +125,7 @@ dotnet_naming_rule.types_and_members_should_be_pascalcase.style = pascal_case
 dotnet_naming_rule.types_and_members_should_be_pascalcase.severity = suggestion
 
 # =========================
-# 常用 Roslyn 診斷（提升品質）
-# =========================
-# 移除未使用 using
-dotnet_diagnostic.IDE0005.severity = warning
-# 使用隱式 new()
-dotnet_diagnostic.IDE0090.severity = suggestion
-# 使用 using 宣告
-dotnet_diagnostic.IDE0063.severity = suggestion
-# 可為 readonly 的欄位
-dotnet_diagnostic.IDE0044.severity = warning
-# 移除未使用參數（可視需求降低嚴重度）
-dotnet_diagnostic.IDE0060.severity = suggestion
-# 簡化/內嵌變數
-dotnet_diagnostic.IDE0007.severity = suggestion
-dotnet_diagnostic.IDE0016.severity = suggestion
-
-# =========================
-# JSON / XML（選）
+# JSON / XML
 # =========================
 [*.{json,xml}]
 indent_style = space

--- a/README.md
+++ b/README.md
@@ -136,6 +136,17 @@ docker system prune -a --volumes
 
 # describe
 
+## Service.Auth
+
+Jwt Control
+
+Jwt.Key 建立語法
+
+```bash
+# 產生後移除所有換行
+openssl rand -base64 64 | tr -d '\n'
+```
+
 ## Service.WebAPI
 
 dotnet add package Swashbuckle.AspNetCore -v 6.7.0

--- a/src/Services/Service.Auth/Controllers/AuthController.cs
+++ b/src/Services/Service.Auth/Controllers/AuthController.cs
@@ -1,0 +1,45 @@
+using System.Security.Claims;
+using Library.Core.Results;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Service.Auth.Models.Auth;
+using Service.Auth.Services.Auth;
+
+namespace Service.Auth.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController(IAuthService authService) : ControllerBase
+{
+    [HttpPost("register")]
+    public async Task<IActionResult> Register(RegisterRequest request)
+    {
+        Result<UserResponse> result = await authService.RegisterAsync(request);
+        return result.Success ? Ok(result) : BadRequest(result);
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login(LoginRequest request)
+    {
+        Result<TokenResponse> result = await authService.LoginAsync(request);
+        return result.Success ? Ok(result) : Unauthorized(result);
+    }
+
+    [Authorize]
+    [HttpGet("me")]
+    public async Task<IActionResult> Me()
+    {
+        string? userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(userId)) return Unauthorized();
+
+        Result<UserResponse> result = await authService.GetUserByIdAsync(Guid.Parse(userId));
+        return result.Success ? Ok(result) : NotFound(result);
+    }
+
+    [HttpPost("refresh")]
+    public async Task<IActionResult> Refresh(RefreshRequest request)
+    {
+        Result<TokenResponse> result = await authService.RefreshAsync(request);
+        return result.Success ? Ok(result) : Unauthorized(result);
+    }
+}

--- a/src/Services/Service.Auth/Controllers/AuthController.cs
+++ b/src/Services/Service.Auth/Controllers/AuthController.cs
@@ -1,7 +1,10 @@
 using System.Security.Claims;
+
 using Library.Core.Results;
+
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+
 using Service.Auth.Models.Auth;
 using Service.Auth.Services.Auth;
 

--- a/src/Services/Service.Auth/Models/Auth/LoginRequest.cs
+++ b/src/Services/Service.Auth/Models/Auth/LoginRequest.cs
@@ -1,0 +1,7 @@
+namespace Service.Auth.Models.Auth;
+
+public class LoginRequest
+{
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/src/Services/Service.Auth/Models/Auth/RefreshRequest.cs
+++ b/src/Services/Service.Auth/Models/Auth/RefreshRequest.cs
@@ -1,0 +1,6 @@
+namespace Service.Auth.Models.Auth;
+
+public class RefreshRequest
+{
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/src/Services/Service.Auth/Models/Auth/RegisterRequest.cs
+++ b/src/Services/Service.Auth/Models/Auth/RegisterRequest.cs
@@ -5,4 +5,5 @@ public class RegisterRequest
     public string Username { get; set; } = string.Empty;
     public string? Email { get; set; }
     public string Password { get; set; } = string.Empty;
+    public List<string> Roles { get; set; } = new();
 }

--- a/src/Services/Service.Auth/Models/Auth/RegisterRequest.cs
+++ b/src/Services/Service.Auth/Models/Auth/RegisterRequest.cs
@@ -1,0 +1,8 @@
+namespace Service.Auth.Models.Auth;
+
+public class RegisterRequest
+{
+    public string Username { get; set; } = string.Empty;
+    public string? Email { get; set; }
+    public string Password { get; set; } = string.Empty;
+}

--- a/src/Services/Service.Auth/Models/Auth/TokenResponse.cs
+++ b/src/Services/Service.Auth/Models/Auth/TokenResponse.cs
@@ -1,0 +1,7 @@
+namespace Service.Auth.Models.Auth;
+
+public class TokenResponse
+{
+    public string AccessToken { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/src/Services/Service.Auth/Models/Auth/UserResponse.cs
+++ b/src/Services/Service.Auth/Models/Auth/UserResponse.cs
@@ -1,0 +1,9 @@
+namespace Service.Auth.Models.Auth;
+
+public class UserResponse
+{
+    public Guid Id { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string? Email { get; set; }
+    public List<string> Roles { get; set; } = new();
+}

--- a/src/Services/Service.Auth/Program.cs
+++ b/src/Services/Service.Auth/Program.cs
@@ -1,10 +1,13 @@
 using System.Text;
+
 using Library.Core.Logging;
 using Library.Core.Middlewares;
 using Library.Database.Contexts.Auth;
+
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+
 using Service.Auth.Services.Auth;
 using Service.Auth.Services.Jwt;
 using Service.Auth.Services.Password;
@@ -63,7 +66,7 @@ namespace Service.Auth
 
         private static void ConfigDatabase(WebApplicationBuilder builder)
         {
-            var connectionString = builder.Configuration.GetConnectionString("PostgreSql");
+            string? connectionString = builder.Configuration.GetConnectionString("PostgreSql");
             if (string.IsNullOrWhiteSpace(connectionString)) throw new InvalidOperationException($"Connection String Not Found.");
             builder.Services.AddDbContext<AuthDbContext>(opt =>
             {

--- a/src/Services/Service.Auth/Service.Auth.csproj
+++ b/src/Services/Service.Auth/Service.Auth.csproj
@@ -16,8 +16,4 @@
     <ProjectReference Include="..\..\Librarys\Library.Database\Library.Database.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Controllers\" />
-  </ItemGroup>
-
 </Project>

--- a/src/Services/Service.Auth/Service.Auth.csproj
+++ b/src/Services/Service.Auth/Service.Auth.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
   </ItemGroup>

--- a/src/Services/Service.Auth/Services/Auth/AuthService.cs
+++ b/src/Services/Service.Auth/Services/Auth/AuthService.cs
@@ -1,7 +1,9 @@
 using Library.Core.Results;
 using Library.Database.Contexts.Auth;
 using Library.Database.Models.Auth;
+
 using Microsoft.EntityFrameworkCore;
+
 using Service.Auth.Models.Auth;
 using Service.Auth.Services.Jwt;
 using Service.Auth.Services.Password;

--- a/src/Services/Service.Auth/Services/Auth/AuthService.cs
+++ b/src/Services/Service.Auth/Services/Auth/AuthService.cs
@@ -1,0 +1,167 @@
+using Library.Core.Results;
+using Library.Database.Contexts.Auth;
+using Library.Database.Models.Auth;
+using Microsoft.EntityFrameworkCore;
+using Service.Auth.Models.Auth;
+using Service.Auth.Services.Jwt;
+using Service.Auth.Services.Password;
+
+namespace Service.Auth.Services.Auth;
+
+public class AuthService(
+    AuthDbContext db,
+    IPasswordHasher passwordHasher,
+    IJwtService jwtService,
+    ILogger<AuthService> logger
+) : IAuthService
+{
+    public async Task<Result<UserResponse>> RegisterAsync(RegisterRequest request)
+    {
+        try
+        {
+            bool exists = await db.Users.AnyAsync(u => u.Username == request.Username);
+            if (exists) return Result<UserResponse>.Fail("Username already exists");
+
+            (string hash, string salt) = passwordHasher.HashPassword(request.Password);
+
+            User user = new()
+            {
+                Username = request.Username,
+                Email = request.Email,
+                PasswordHash = hash,
+                PasswordSalt = salt,
+                Roles = new List<string>(),
+                IsActive = true
+            };
+
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+
+            UserResponse response = new()
+            {
+                Id = user.Id,
+                Username = user.Username,
+                Email = user.Email,
+                Roles = user.Roles
+            };
+
+            return Result<UserResponse>.Ok(response);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "AuthService.RegisterAsync Error");
+            throw;
+        }
+    }
+
+    public async Task<Result<TokenResponse>> LoginAsync(LoginRequest request)
+    {
+        try
+        {
+            User? user = await db.Users.FirstOrDefaultAsync(u => u.Username == request.Username);
+            if (user is null)
+            {
+                return Result<TokenResponse>.Fail("Invalid credentials");
+            }
+
+            bool valid = passwordHasher.VerifyPassword(request.Password, user.PasswordHash, user.PasswordSalt);
+            if (!valid) return Result<TokenResponse>.Fail("Invalid credentials");
+
+            string accessToken = jwtService.GenerateAccessToken(user);
+            string refreshToken = jwtService.GenerateRefreshToken();
+
+            RefreshToken refreshEntity = new()
+            {
+                UserId = user.Id,
+                Token = refreshToken,
+                ExpiresAt = DateTime.UtcNow.AddDays(jwtService.RefreshTokenExpiryDays)
+            };
+
+            user.LastLoginAt = DateTime.UtcNow;
+
+            db.RefreshTokens.Add(refreshEntity);
+            await db.SaveChangesAsync();
+
+            TokenResponse response = new()
+            {
+                AccessToken = accessToken,
+                RefreshToken = refreshToken
+            };
+
+            return Result<TokenResponse>.Ok(response);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "AuthService.LoginAsync Error");
+            throw;
+        }
+    }
+
+    public async Task<Result<UserResponse>> GetUserByIdAsync(Guid userId)
+    {
+        try
+        {
+            User? user = await db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId);
+            if (user is null) return Result<UserResponse>.Fail("User not found");
+
+            UserResponse response = new()
+            {
+                Id = user.Id,
+                Username = user.Username,
+                Email = user.Email,
+                Roles = user.Roles
+            };
+
+            return Result<UserResponse>.Ok(response);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "AuthService.GetUserByIdAsync Error");
+            throw;
+        }
+    }
+
+    public async Task<Result<TokenResponse>> RefreshAsync(RefreshRequest request)
+    {
+        try
+        {
+            RefreshToken? tokenEntity = await db.RefreshTokens.Include(r => r.User)
+                .FirstOrDefaultAsync(r => r.Token == request.RefreshToken);
+
+            if (tokenEntity is null || tokenEntity.RevokedAt != null || tokenEntity.ExpiresAt < DateTime.UtcNow)
+            {
+                return Result<TokenResponse>.Fail("Invalid refresh token");
+            }
+
+            tokenEntity.RevokedAt = DateTime.UtcNow;
+
+            User user = tokenEntity.User;
+
+            string newAccessToken = jwtService.GenerateAccessToken(user);
+            string newRefreshToken = jwtService.GenerateRefreshToken();
+
+            RefreshToken newRefreshEntity = new()
+            {
+                UserId = user.Id,
+                Token = newRefreshToken,
+                ExpiresAt = DateTime.UtcNow.AddDays(jwtService.RefreshTokenExpiryDays)
+            };
+
+            db.RefreshTokens.Add(newRefreshEntity);
+            await db.SaveChangesAsync();
+
+            TokenResponse response = new()
+            {
+                AccessToken = newAccessToken,
+                RefreshToken = newRefreshToken
+            };
+
+            return Result<TokenResponse>.Ok(response);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "AuthService.RefreshAsync Error");
+            throw;
+        }
+    }
+}

--- a/src/Services/Service.Auth/Services/Auth/IAuthService.cs
+++ b/src/Services/Service.Auth/Services/Auth/IAuthService.cs
@@ -1,4 +1,5 @@
 using Library.Core.Results;
+
 using Service.Auth.Models.Auth;
 
 namespace Service.Auth.Services.Auth;

--- a/src/Services/Service.Auth/Services/Auth/IAuthService.cs
+++ b/src/Services/Service.Auth/Services/Auth/IAuthService.cs
@@ -1,0 +1,12 @@
+using Library.Core.Results;
+using Service.Auth.Models.Auth;
+
+namespace Service.Auth.Services.Auth;
+
+public interface IAuthService
+{
+    Task<Result<UserResponse>> RegisterAsync(RegisterRequest request);
+    Task<Result<TokenResponse>> LoginAsync(LoginRequest request);
+    Task<Result<UserResponse>> GetUserByIdAsync(Guid userId);
+    Task<Result<TokenResponse>> RefreshAsync(RefreshRequest request);
+}

--- a/src/Services/Service.Auth/Services/Jwt/IJwtService.cs
+++ b/src/Services/Service.Auth/Services/Jwt/IJwtService.cs
@@ -1,0 +1,10 @@
+using Library.Database.Models.Auth;
+
+namespace Service.Auth.Services.Jwt;
+
+public interface IJwtService
+{
+    string GenerateAccessToken(User user);
+    string GenerateRefreshToken();
+    int RefreshTokenExpiryDays { get; }
+}

--- a/src/Services/Service.Auth/Services/Jwt/JwtService.cs
+++ b/src/Services/Service.Auth/Services/Jwt/JwtService.cs
@@ -1,0 +1,43 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using Library.Database.Models.Auth;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Service.Auth.Services.Jwt;
+
+public class JwtService(IConfiguration configuration) : IJwtService
+{
+    private readonly IConfiguration _configuration = configuration;
+
+    public string GenerateAccessToken(User user)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["Jwt:Key"]!));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        Claim[] claims =
+        [
+            new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+            new Claim(ClaimTypes.Name, user.Username)
+        ];
+
+        var token = new JwtSecurityToken(
+            issuer: _configuration["Jwt:Issuer"],
+            audience: _configuration["Jwt:Audience"],
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(int.Parse(_configuration["Jwt:AccessTokenExpiresMinutes"] ?? "30")),
+            signingCredentials: creds
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    public string GenerateRefreshToken()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(32);
+        return Convert.ToBase64String(bytes);
+    }
+
+    public int RefreshTokenExpiryDays => int.Parse(_configuration["Jwt:RefreshTokenExpiresDays"] ?? "7");
+}

--- a/src/Services/Service.Auth/Services/Jwt/JwtService.cs
+++ b/src/Services/Service.Auth/Services/Jwt/JwtService.cs
@@ -2,7 +2,9 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
+
 using Library.Database.Models.Auth;
+
 using Microsoft.IdentityModel.Tokens;
 
 namespace Service.Auth.Services.Jwt;
@@ -13,8 +15,8 @@ public class JwtService(IConfiguration configuration) : IJwtService
 
     public string GenerateAccessToken(User user)
     {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["Jwt:Key"]!));
-        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        SymmetricSecurityKey key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["Jwt:Key"]!));
+        SigningCredentials signingCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
         Claim[] claims =
         [
@@ -22,12 +24,12 @@ public class JwtService(IConfiguration configuration) : IJwtService
             new Claim(ClaimTypes.Name, user.Username)
         ];
 
-        var token = new JwtSecurityToken(
+        JwtSecurityToken token = new JwtSecurityToken(
             issuer: _configuration["Jwt:Issuer"],
             audience: _configuration["Jwt:Audience"],
             claims: claims,
             expires: DateTime.UtcNow.AddMinutes(int.Parse(_configuration["Jwt:AccessTokenExpiresMinutes"] ?? "30")),
-            signingCredentials: creds
+            signingCredentials: signingCredentials
         );
 
         return new JwtSecurityTokenHandler().WriteToken(token);
@@ -35,7 +37,7 @@ public class JwtService(IConfiguration configuration) : IJwtService
 
     public string GenerateRefreshToken()
     {
-        var bytes = RandomNumberGenerator.GetBytes(32);
+        byte[] bytes = RandomNumberGenerator.GetBytes(32);
         return Convert.ToBase64String(bytes);
     }
 

--- a/src/Services/Service.Auth/Services/Password/IPasswordHasher.cs
+++ b/src/Services/Service.Auth/Services/Password/IPasswordHasher.cs
@@ -1,0 +1,7 @@
+namespace Service.Auth.Services.Password;
+
+public interface IPasswordHasher
+{
+    (string Hash, string Salt) HashPassword(string password);
+    bool VerifyPassword(string password, string hash, string salt);
+}

--- a/src/Services/Service.Auth/Services/Password/PasswordHasher.cs
+++ b/src/Services/Service.Auth/Services/Password/PasswordHasher.cs
@@ -1,0 +1,26 @@
+using System.Security.Cryptography;
+
+namespace Service.Auth.Services.Password;
+
+public class PasswordHasher : IPasswordHasher
+{
+    private const int SaltSize = 16; // 128 bit
+    private const int KeySize = 32; // 256 bit
+    private const int Iterations = 100000;
+
+    public (string Hash, string Salt) HashPassword(string password)
+    {
+        byte[] salt = RandomNumberGenerator.GetBytes(SaltSize);
+        using var pbkdf2 = new Rfc2898DeriveBytes(password, salt, Iterations, HashAlgorithmName.SHA256);
+        byte[] hash = pbkdf2.GetBytes(KeySize);
+        return (Convert.ToBase64String(hash), Convert.ToBase64String(salt));
+    }
+
+    public bool VerifyPassword(string password, string hash, string salt)
+    {
+        byte[] saltBytes = Convert.FromBase64String(salt);
+        using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, Iterations, HashAlgorithmName.SHA256);
+        byte[] computed = pbkdf2.GetBytes(KeySize);
+        return CryptographicOperations.FixedTimeEquals(computed, Convert.FromBase64String(hash));
+    }
+}

--- a/src/Services/Service.Auth/Services/Password/PasswordHasher.cs
+++ b/src/Services/Service.Auth/Services/Password/PasswordHasher.cs
@@ -11,7 +11,7 @@ public class PasswordHasher : IPasswordHasher
     public (string Hash, string Salt) HashPassword(string password)
     {
         byte[] salt = RandomNumberGenerator.GetBytes(SaltSize);
-        using var pbkdf2 = new Rfc2898DeriveBytes(password, salt, Iterations, HashAlgorithmName.SHA256);
+        using Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(password, salt, Iterations, HashAlgorithmName.SHA256);
         byte[] hash = pbkdf2.GetBytes(KeySize);
         return (Convert.ToBase64String(hash), Convert.ToBase64String(salt));
     }
@@ -19,7 +19,7 @@ public class PasswordHasher : IPasswordHasher
     public bool VerifyPassword(string password, string hash, string salt)
     {
         byte[] saltBytes = Convert.FromBase64String(salt);
-        using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, Iterations, HashAlgorithmName.SHA256);
+        using Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, Iterations, HashAlgorithmName.SHA256);
         byte[] computed = pbkdf2.GetBytes(KeySize);
         return CryptographicOperations.FixedTimeEquals(computed, Convert.FromBase64String(hash));
     }

--- a/src/Services/Service.Auth/appsettings.Development.json
+++ b/src/Services/Service.Auth/appsettings.Development.json
@@ -1,5 +1,12 @@
 {
   "ConnectionStrings": {
     "PostgreSql": "Host=localhost;Port=5432;Database=csharp_sample_solution_db;Username=db_admin;Password=P@ssw0rd"
+  },
+  "Jwt": {
+    "Key": "ThisIsASecretKeyForDev",
+    "Issuer": "SampleAuthService",
+    "Audience": "SampleAuthService",
+    "AccessTokenExpiresMinutes": 30,
+    "RefreshTokenExpiresDays": 7
   }
 }

--- a/src/Services/Service.Auth/appsettings.Development.json
+++ b/src/Services/Service.Auth/appsettings.Development.json
@@ -1,12 +1,5 @@
 {
   "ConnectionStrings": {
     "PostgreSql": "Host=localhost;Port=5432;Database=csharp_sample_solution_db;Username=db_admin;Password=P@ssw0rd"
-  },
-  "Jwt": {
-    "Key": "ThisIsASecretKeyForDev",
-    "Issuer": "SampleAuthService",
-    "Audience": "SampleAuthService",
-    "AccessTokenExpiresMinutes": 30,
-    "RefreshTokenExpiresDays": 7
   }
 }

--- a/src/Services/Service.Auth/appsettings.Docker.json
+++ b/src/Services/Service.Auth/appsettings.Docker.json
@@ -1,12 +1,5 @@
 {
   "ConnectionStrings": {
     "PostgreSql": "Host=postgres;Port=5432;Database=csharp_sample_solution_db;Username=db_admin;Password=P@ssw0rd"
-  },
-  "Jwt": {
-    "Key": "ThisIsASecretKeyForDev",
-    "Issuer": "SampleAuthService",
-    "Audience": "SampleAuthService",
-    "AccessTokenExpiresMinutes": 30,
-    "RefreshTokenExpiresDays": 7
   }
 }

--- a/src/Services/Service.Auth/appsettings.Docker.json
+++ b/src/Services/Service.Auth/appsettings.Docker.json
@@ -1,5 +1,12 @@
 {
   "ConnectionStrings": {
     "PostgreSql": "Host=postgres;Port=5432;Database=csharp_sample_solution_db;Username=db_admin;Password=P@ssw0rd"
+  },
+  "Jwt": {
+    "Key": "ThisIsASecretKeyForDev",
+    "Issuer": "SampleAuthService",
+    "Audience": "SampleAuthService",
+    "AccessTokenExpiresMinutes": 30,
+    "RefreshTokenExpiresDays": 7
   }
 }

--- a/src/Services/Service.Auth/appsettings.json
+++ b/src/Services/Service.Auth/appsettings.json
@@ -30,9 +30,9 @@
     ]
   },
   "Jwt": {
-    "Key": "ThisIsASecretKeyForDev",
-    "Issuer": "SampleAuthService",
-    "Audience": "SampleAuthService",
+    "Key": "Tsko2qxkyyC4LU21lJNnafp/rhJxakP6V52HzAJv5OQeXXTA4T2fY0aFUqi1Z8HKKANeWsgIfzljuHiU3IR3Jg==",
+    "Issuer": "YourCompany.Auth",
+    "Audience": "YourCompany.Client",
     "AccessTokenExpiresMinutes": 30,
     "RefreshTokenExpiresDays": 7
   }

--- a/src/Services/Service.Auth/appsettings.json
+++ b/src/Services/Service.Auth/appsettings.json
@@ -28,5 +28,12 @@
         }
       }
     ]
+  },
+  "Jwt": {
+    "Key": "ThisIsASecretKeyForDev",
+    "Issuer": "SampleAuthService",
+    "Audience": "SampleAuthService",
+    "AccessTokenExpiresMinutes": 30,
+    "RefreshTokenExpiresDays": 7
   }
 }


### PR DESCRIPTION
## Summary
- implement password hashing with PBKDF2 and JWT token generation
- add auth service and controller for register, login, self, and refresh
- configure Auth service with JWT authentication and PostgreSQL context

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b2da3767ec832aa694c841370d9515