### PR TITLE
Refactor service registration with reusable extensions

### DIFF
--- a/src/Librarys/Library.ApiClient/Services/Auth/AuthApiClientExtensions.cs
+++ b/src/Librarys/Library.ApiClient/Services/Auth/AuthApiClientExtensions.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Refit;
+
+namespace Library.ApiClient.Services.Auth;
+
+public static class AuthApiClientExtensions
+{
+    /// <summary>
+    /// Register the Auth API Refit client using configuration for the base address.
+    /// </summary>
+    public static IServiceCollection AddAuthApiClient(this IServiceCollection services, IConfiguration configuration)
+    {
+        string? baseUrl = configuration["AuthApi:BaseUrl"];
+        if (string.IsNullOrWhiteSpace(baseUrl))
+            throw new InvalidOperationException("AuthApi:BaseUrl is not configured.");
+
+        services
+            .AddRefitClient<IAuthApi>()
+            .ConfigureHttpClient(c => c.BaseAddress = new Uri(baseUrl));
+
+        return services;
+    }
+}

--- a/src/Librarys/Library.Core/Authentication/JwtAuthenticationExtensions.cs
+++ b/src/Librarys/Library.Core/Authentication/JwtAuthenticationExtensions.cs
@@ -1,0 +1,37 @@
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Library.Core.Authentication;
+
+public static class JwtAuthenticationExtensions
+{
+    /// <summary>
+    /// Add JWT bearer authentication configured from the provided <see cref="IConfiguration"/>.
+    /// </summary>
+    public static IServiceCollection AddJwtAuthentication(this IServiceCollection services, IConfiguration configuration)
+    {
+        services
+            .AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+            })
+            .AddJwtBearer(options =>
+            {
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateIssuerSigningKey = true,
+                    ValidIssuer = configuration["Jwt:Issuer"],
+                    ValidAudience = configuration["Jwt:Audience"],
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(configuration["Jwt:Key"]!))
+                };
+            });
+
+        return services;
+    }
+}

--- a/src/Services/Service.WebAPI/Program.cs
+++ b/src/Services/Service.WebAPI/Program.cs
@@ -1,16 +1,11 @@
-using System.Text;
-
 using Library.ApiClient.Services.Auth;
+using Library.Core.Authentication;
 using Library.Core.Logging;
 using Library.Core.Middlewares;
 using Library.Core.Time;
 using Library.Database.Contexts.Public;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 
 using Microsoft.EntityFrameworkCore;
-using Microsoft.IdentityModel.Tokens;
-
-using Refit;
 
 using Service.WebAPI.Services.Country;
 
@@ -41,27 +36,8 @@ namespace Service.WebAPI
             builder.Services.AddScoped<ICountryService, CountryService>();
             builder.Services.AddTimezoneService();
 
-            builder.Services.AddAuthentication(options =>
-            {
-                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-                options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-            }).AddJwtBearer(options =>
-            {
-                options.TokenValidationParameters = new TokenValidationParameters
-                {
-                    ValidateIssuer = true,
-                    ValidateAudience = true,
-                    ValidateIssuerSigningKey = true,
-                    ValidIssuer = builder.Configuration["Jwt:Issuer"],
-                    ValidAudience = builder.Configuration["Jwt:Audience"],
-                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
-                };
-            });
-
-            builder.Services
-                .AddRefitClient<IAuthApi>()
-                .ConfigureHttpClient(c =>
-                    c.BaseAddress = new Uri(builder.Configuration["AuthApi:BaseUrl"]!));
+            builder.Services.AddJwtAuthentication(builder.Configuration);
+            builder.Services.AddAuthApiClient(builder.Configuration);
         }
 
         private static void ConfigSwagger(WebApplicationBuilder builder)


### PR DESCRIPTION
## Summary
- add `AddAuthApiClient` extension for Refit client registration
- add `AddJwtAuthentication` extension to centralize JWT bearer setup
- simplify `Service.WebAPI` Program configuration using new extensions

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b4906d2740832ab95dd4fcb5def5d1