### PR TITLE
Add token validation attribute for WebAPI

### DIFF
--- a/src/Librarys/Library.ApiClient/Attributes/ValidateTokenAttribute.cs
+++ b/src/Librarys/Library.ApiClient/Attributes/ValidateTokenAttribute.cs
@@ -1,0 +1,52 @@
+using Library.ApiClient.Models.Auth;
+using Library.ApiClient.Services.Auth;
+using Library.Core.Results;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+using Refit;
+
+namespace Library.ApiClient.Attributes;
+
+/// <summary>
+/// Action filter attribute that validates the Authorization token by calling the Auth API.
+/// If the token is invalid or missing, an <see cref="UnauthorizedResult"/> is returned.
+/// When the token is valid, the user information will be stored in <see cref="HttpContext.Items"/> with key <c>UserInfo</c>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public class ValidateTokenAttribute : Attribute, IAsyncActionFilter
+{
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        string authorization = context.HttpContext.Request.Headers["Authorization"].ToString();
+        if (string.IsNullOrWhiteSpace(authorization))
+        {
+            context.Result = new UnauthorizedResult();
+            return;
+        }
+
+        IAuthApi? authApi = context.HttpContext.RequestServices.GetService(typeof(IAuthApi)) as IAuthApi;
+        if (authApi is null)
+        {
+            context.Result = new UnauthorizedResult();
+            return;
+        }
+
+        ApiResponse<Result<UserInfoResponse>> response = await authApi.ValidateTokenAsync(new ValidateTokenRequest
+        {
+            Token = authorization
+        });
+
+        if (!response.IsSuccessStatusCode || response.Content?.Data is null || !response.Content.Success)
+        {
+            context.Result = new UnauthorizedResult();
+            return;
+        }
+
+        context.HttpContext.Items["UserInfo"] = response.Content.Data;
+
+        await next();
+    }
+}
+

--- a/src/Librarys/Library.ApiClient/Library.ApiClient.csproj
+++ b/src/Librarys/Library.ApiClient/Library.ApiClient.csproj
@@ -16,4 +16,8 @@
     <ProjectReference Include="..\Library.Core\Library.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- create ValidateToken attribute that checks tokens with the Auth API and stores user info
- allow ApiClient project to reference ASP.NET Core types
- use new attribute in CountryController to remove manual token checks

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b85ee8f678832ab047117339b79774