### PR TITLE
refactor: improve token validation and role handling

### DIFF
--- a/src/Librarys/Library.ApiClient/Attributes/ValidateTokenAttribute.cs
+++ b/src/Librarys/Library.ApiClient/Attributes/ValidateTokenAttribute.cs
@@ -1,9 +1,14 @@
+using System;
+using System.Linq;
+
+using Library.ApiClient.Constants;
 using Library.ApiClient.Models.Auth;
 using Library.ApiClient.Services.Auth;
 using Library.Core.Results;
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
 
 using Refit;
 
@@ -17,25 +22,35 @@ namespace Library.ApiClient.Attributes;
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 public class ValidateTokenAttribute : Attribute, IAsyncActionFilter
 {
+    public string? Roles { get; set; }
+
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
-        string authorization = context.HttpContext.Request.Headers["Authorization"].ToString();
-        if (string.IsNullOrWhiteSpace(authorization))
+        if (!context.HttpContext.Request.Headers.TryGetValue("Authorization", out var header) || header.Count == 0)
         {
             context.Result = new UnauthorizedResult();
             return;
         }
 
-        IAuthApi? authApi = context.HttpContext.RequestServices.GetService(typeof(IAuthApi)) as IAuthApi;
-        if (authApi is null)
+        string? authorization = header.FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(authorization) || !authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
         {
             context.Result = new UnauthorizedResult();
             return;
         }
+
+        string token = authorization["Bearer ".Length..].Trim();
+        if (string.IsNullOrEmpty(token))
+        {
+            context.Result = new UnauthorizedResult();
+            return;
+        }
+
+        IAuthApi authApi = context.HttpContext.RequestServices.GetRequiredService<IAuthApi>();
 
         ApiResponse<Result<ValidateTokenResponse>> response = await authApi.ValidateTokenAsync(new ValidateTokenRequest
         {
-            Token = authorization
+            Token = token
         });
 
         if (!response.IsSuccessStatusCode || response.Content?.Data is null || !response.Content.Success)
@@ -44,7 +59,18 @@ public class ValidateTokenAttribute : Attribute, IAsyncActionFilter
             return;
         }
 
-        context.HttpContext.Items["TokenInfo"] = response.Content.Data;
+        ValidateTokenResponse tokenInfo = response.Content.Data;
+        context.HttpContext.Items[HttpContextItemKeys.TokenInfo] = tokenInfo;
+
+        if (!string.IsNullOrWhiteSpace(Roles))
+        {
+            string[] requiredRoles = Roles.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (!requiredRoles.Any(role => tokenInfo.Roles.Contains(role)))
+            {
+                context.Result = new ForbidResult();
+                return;
+            }
+        }
 
         await next();
     }

--- a/src/Librarys/Library.ApiClient/Constants/HttpContextItemKeys.cs
+++ b/src/Librarys/Library.ApiClient/Constants/HttpContextItemKeys.cs
@@ -1,0 +1,6 @@
+namespace Library.ApiClient.Constants;
+
+public static class HttpContextItemKeys
+{
+    public const string TokenInfo = "TokenInfo";
+}

--- a/src/Services/Service.WebAPI/Controllers/CountryController.cs
+++ b/src/Services/Service.WebAPI/Controllers/CountryController.cs
@@ -1,5 +1,4 @@
 using Library.ApiClient.Attributes;
-using Library.ApiClient.Models.Auth;
 using Library.Core.Results;
 using Library.Database.Models.Public;
 
@@ -34,19 +33,12 @@ namespace Service.WebAPI.Controllers
             return result.Success ? Ok(result) : NotFound(result);
         }
 
-        [ValidateToken]
+        [ValidateToken(Roles = "admin")]
         [HttpGet("localTime/{countryName}")]
         public async Task<IActionResult> GetLocalTime(
             string countryName
         )
         {
-            if (HttpContext.Items["TokenInfo"] is not ValidateTokenResponse tokenInfo)
-            {
-                return Unauthorized();
-            }
-
-            if (!tokenInfo.Roles.Contains("admin")) return Forbid();
-
             Result<LocalTimeResponse> result = await countryService.GetLocalTimeAsync(countryName);
             if (result.Success) return Ok(result);
             return result.Message == "Country not found"
@@ -54,7 +46,7 @@ namespace Service.WebAPI.Controllers
                 : StatusCode(StatusCodes.Status500InternalServerError, result);
         }
 
-        [ValidateToken]
+        [ValidateToken(Roles = "admin")]
         [HttpPost("add")]
         public async Task<IActionResult> InsertCountry(
             [FromBody] CreateCountryRequest request


### PR DESCRIPTION
## Summary
- Harden token validation with proper Authorization parsing and DI usage
- Add role enforcement and HttpContext item constant
- Require admin role for country time lookup and insertion

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b87a8a9390832aaab7089622dd529d