### PR TITLE
feat(schedule): subscribe to RabbitMQ messages

### DIFF
--- a/src/Services/Service.ScheduleJob/Program.cs
+++ b/src/Services/Service.ScheduleJob/Program.cs
@@ -1,6 +1,8 @@
 using Library.Core.Logging;
 using Library.Core.Middlewares;
 using Library.Database.Contexts.Public;
+using Library.RabbitMQ.Options;
+using Library.RabbitMQ.Services;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
@@ -8,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Quartz;
 
 using Service.ScheduleJob.Jobs;
+using Service.ScheduleJob.Services;
 
 namespace Service.ScheduleJob
 {
@@ -20,6 +23,7 @@ namespace Service.ScheduleJob
             ConfigBasic(builder);
             ConfigDatabase(builder);
             ConfigQuartz(builder);
+            ConfigRabbitMq(builder);
             ConfigSerilog(builder);
             ConfigApp(builder);
         }
@@ -61,6 +65,13 @@ namespace Service.ScheduleJob
 
             // 啟用 Quartz Hosted Service
             builder.Services.AddQuartzHostedService(opt => { opt.WaitForJobsToComplete = true; });
+        }
+
+        private static void ConfigRabbitMq(WebApplicationBuilder builder)
+        {
+            builder.Services.Configure<RabbitMqOptions>(builder.Configuration.GetSection("RabbitMq"));
+            builder.Services.AddSingleton<IRabbitMqService, RabbitMqService>();
+            builder.Services.AddHostedService<RabbitMqConsumerService>();
         }
 
         private static void ConfigSerilog(WebApplicationBuilder builder) => builder.UseSerilogLogging();

--- a/src/Services/Service.ScheduleJob/Service.ScheduleJob.csproj
+++ b/src/Services/Service.ScheduleJob/Service.ScheduleJob.csproj
@@ -16,5 +16,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Librarys\Library.Core\Library.Core.csproj" />
     <ProjectReference Include="..\..\Librarys\Library.Database\Library.Database.csproj" />
+    <ProjectReference Include="..\..\Librarys\Library.RabbitMQ\Library.RabbitMQ.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Services/Service.ScheduleJob/Services/RabbitMqConsumerService.cs
+++ b/src/Services/Service.ScheduleJob/Services/RabbitMqConsumerService.cs
@@ -1,0 +1,37 @@
+using Library.RabbitMQ.Services;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Service.ScheduleJob.Services;
+
+public class RabbitMqConsumerService : IHostedService
+{
+    private readonly IRabbitMqService _rabbitMqService;
+    private readonly ILogger<RabbitMqConsumerService> _logger;
+    private readonly string _queueName;
+
+    public RabbitMqConsumerService(
+        IRabbitMqService rabbitMqService,
+        IConfiguration configuration,
+        ILogger<RabbitMqConsumerService> logger)
+    {
+        _rabbitMqService = rabbitMqService;
+        _logger = logger;
+        _queueName = configuration.GetValue<string>("RabbitMq:Queue") ?? "schedule-job-queue";
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _rabbitMqService.Subscribe(_queueName, message =>
+        {
+            _logger.LogInformation("Receive RabbitMQ message: {Message}", message);
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+

--- a/src/Services/Service.ScheduleJob/appsettings.json
+++ b/src/Services/Service.ScheduleJob/appsettings.json
@@ -11,6 +11,12 @@
     }
   },
   "AllowedHosts": "*",
+  "RabbitMq": {
+    "HostName": "localhost",
+    "UserName": "guest",
+    "Password": "guest",
+    "Queue": "schedule-job-queue"
+  },
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console" ],
     "MinimumLevel": {


### PR DESCRIPTION
## Summary
- add RabbitMQ consumer service to schedule job service
- wire up RabbitMQ options and hosted consumer

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd13514fdc832ab70ca444029e0172