### PR TITLE
Add RabbitMQ consumer for country updates in ScheduleJob

### DIFF
--- a/src/Services/Service.ScheduleJob/Program.cs
+++ b/src/Services/Service.ScheduleJob/Program.cs
@@ -1,13 +1,13 @@
 using Library.Core.Logging;
 using Library.Core.Middlewares;
 using Library.Database.Contexts.Public;
-
+using Library.RabbitMQ.Options;
+using Library.RabbitMQ.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
-
 using Quartz;
-
 using Service.ScheduleJob.Jobs;
+using Service.ScheduleJob.Services;
 
 namespace Service.ScheduleJob
 {
@@ -18,6 +18,8 @@ namespace Service.ScheduleJob
             WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
             ConfigBasic(builder);
+            ConfigService(builder);
+            ConfigRabbitMq(builder);
             ConfigDatabase(builder);
             ConfigQuartz(builder);
             ConfigSerilog(builder);
@@ -30,10 +32,22 @@ namespace Service.ScheduleJob
             builder.Services.AddCors();
         }
 
+        private static void ConfigService(WebApplicationBuilder builder)
+        {
+            builder.Services.AddScoped<ICountryChangeService, CountryChangeService>();
+        }
+
+        private static void ConfigRabbitMq(WebApplicationBuilder builder)
+        {
+            builder.Services.Configure<RabbitMqOptions>(builder.Configuration.GetSection("RabbitMq"));
+            builder.Services.AddSingleton<IRabbitMqService, RabbitMqService>();
+        }
+
         private static void ConfigDatabase(WebApplicationBuilder builder)
         {
             var connectionString = builder.Configuration.GetConnectionString("PostgreSql");
-            if (string.IsNullOrWhiteSpace(connectionString)) throw new InvalidOperationException($"Connection String Not Found.");
+            if (string.IsNullOrWhiteSpace(connectionString))
+                throw new InvalidOperationException("Connection String Not Found.");
 
             builder.Services.AddDbContext<PublicDbContext>(opt =>
             {
@@ -44,31 +58,28 @@ namespace Service.ScheduleJob
 
         private static void ConfigQuartz(WebApplicationBuilder builder)
         {
-            // 加入 Quartz
             builder.Services.AddQuartz(q =>
             {
-                // 註冊 Job
                 var jobKey = new JobKey("TimeReportJob");
                 q.AddJob<TimeReportJob>(opts => opts.WithIdentity(jobKey));
-
-                // 建立觸發器：每分鐘執行一次
                 q.AddTrigger(opts => opts
-                        .ForJob(jobKey)
-                        .WithIdentity("TimeReportJob-trigger")
-                        .WithCronSchedule("0 * * * * ?") // Quartz Cron：每分鐘 0 秒觸發
-                );
+                    .ForJob(jobKey)
+                    .WithIdentity("TimeReportJob-trigger")
+                    .WithCronSchedule("0 * * * * ?"));
             });
 
-            // 啟用 Quartz Hosted Service
             builder.Services.AddQuartzHostedService(opt => { opt.WaitForJobsToComplete = true; });
         }
 
         private static void ConfigSerilog(WebApplicationBuilder builder) => builder.UseSerilogLogging();
 
-
         private static void ConfigApp(WebApplicationBuilder builder)
         {
             WebApplication app = builder.Build();
+
+            IRabbitMqService rabbit = app.Services.GetRequiredService<IRabbitMqService>();
+            ICountryChangeService countryService = app.Services.GetRequiredService<ICountryChangeService>();
+            rabbit.Subscribe("queue.change_country_table", countryService.HandleMessage);
 
             app.UseHttpsRedirection();
 

--- a/src/Services/Service.ScheduleJob/Service.ScheduleJob.csproj
+++ b/src/Services/Service.ScheduleJob/Service.ScheduleJob.csproj
@@ -16,5 +16,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Librarys\Library.Core\Library.Core.csproj" />
     <ProjectReference Include="..\..\Librarys\Library.Database\Library.Database.csproj" />
+    <ProjectReference Include="..\..\Librarys\Library.RabbitMQ\Library.RabbitMQ.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Services/Service.ScheduleJob/Services/CountryChangeService.cs
+++ b/src/Services/Service.ScheduleJob/Services/CountryChangeService.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using Library.Database.Contexts.Public;
+using Library.Database.Models.Public;
+using Microsoft.EntityFrameworkCore;
+
+namespace Service.ScheduleJob.Services;
+
+public class CountryChangeService(PublicDbContext dbContext, ILogger<CountryChangeService> logger) : ICountryChangeService
+{
+    public void HandleMessage(string message)
+    {
+        try
+        {
+            CountryInfo? country = JsonSerializer.Deserialize<CountryInfo>(message);
+            if (country == null)
+            {
+                logger.LogWarning("Received invalid country message: {Message}", message);
+                return;
+            }
+
+            CountryInfo? existing = dbContext.CountryInfo.AsNoTracking().FirstOrDefault(x => x.Id == country.Id);
+            if (existing == null)
+            {
+                dbContext.CountryInfo.Add(country);
+            }
+            else
+            {
+                dbContext.CountryInfo.Update(country);
+            }
+            dbContext.SaveChanges();
+            logger.LogInformation("Processed country change for {CountryName}", country.CountryName);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to process country change message");
+        }
+    }
+}

--- a/src/Services/Service.ScheduleJob/Services/ICountryChangeService.cs
+++ b/src/Services/Service.ScheduleJob/Services/ICountryChangeService.cs
@@ -1,0 +1,6 @@
+namespace Service.ScheduleJob.Services;
+
+public interface ICountryChangeService
+{
+    void HandleMessage(string message);
+}

--- a/src/Services/Service.ScheduleJob/appsettings.Development.json
+++ b/src/Services/Service.ScheduleJob/appsettings.Development.json
@@ -1,5 +1,10 @@
 {
   "ConnectionStrings": {
     "PostgreSql": "Host=localhost;Port=5432;Database=csharp_sample_solution_db;Username=db_admin;Password=P@ssw0rd"
+  },
+  "RabbitMq": {
+    "HostName": "localhost",
+    "UserName": "admin",
+    "Password": "admin"
   }
 }

--- a/src/Services/Service.ScheduleJob/appsettings.json
+++ b/src/Services/Service.ScheduleJob/appsettings.json
@@ -11,6 +11,11 @@
     }
   },
   "AllowedHosts": "*",
+  "RabbitMq": {
+    "HostName": "localhost",
+    "UserName": "guest",
+    "Password": "guest"
+  },
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console" ],
     "MinimumLevel": {


### PR DESCRIPTION
## Summary
- handle `queue.change_country_table` messages in Service.ScheduleJob
- register RabbitMQ configuration and services
- store country changes via new CountryChangeService

## Testing
- `dotnet build Solution.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd28be0180832a9275828c4456cf9b