### PR TITLE
feat: add rabbitmq listener hosted service

### DIFF
--- a/src/Librarys/Library.RabbitMQ/Library.RabbitMQ.csproj
+++ b/src/Librarys/Library.RabbitMQ/Library.RabbitMQ.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.8" />
     <PackageReference Include="RabbitMQ.Client" Version="6.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Librarys/Library.RabbitMQ/RabbitListenerHostedService.cs
+++ b/src/Librarys/Library.RabbitMQ/RabbitListenerHostedService.cs
@@ -11,7 +11,7 @@ public class RabbitListenerHostedService(IRabbitMqService rabbitMqService, ILogg
     private const string QueueName = "queue.change_country_table";
     private const string EventKey = "key.change_country_table";
 
-    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _rabbitMqService.Subscribe(QueueName, async message =>
         {
@@ -19,6 +19,6 @@ public class RabbitListenerHostedService(IRabbitMqService rabbitMqService, ILogg
             await RmqEventDispatcher.DispatchAsync(EventKey);
         });
 
-        return Task.CompletedTask;
+        await Task.Delay(Timeout.Infinite, stoppingToken);
     }
 }

--- a/src/Librarys/Library.RabbitMQ/RabbitListenerHostedService.cs
+++ b/src/Librarys/Library.RabbitMQ/RabbitListenerHostedService.cs
@@ -1,0 +1,24 @@
+using Library.RabbitMQ.Services;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Library.RabbitMQ;
+
+public class RabbitListenerHostedService(IRabbitMqService rabbitMqService, ILogger<RabbitListenerHostedService> logger) : BackgroundService
+{
+    private readonly IRabbitMqService _rabbitMqService = rabbitMqService;
+    private readonly ILogger<RabbitListenerHostedService> _logger = logger;
+    private const string QueueName = "queue.change_country_table";
+    private const string EventKey = "key.change_country_table";
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _rabbitMqService.Subscribe(QueueName, async message =>
+        {
+            _logger.LogInformation("Received message: {Message}", message);
+            await RmqEventDispatcher.DispatchAsync(EventKey);
+        });
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Librarys/Library.RabbitMQ/Services/IRabbitMqService.cs
+++ b/src/Librarys/Library.RabbitMQ/Services/IRabbitMqService.cs
@@ -3,4 +3,5 @@ namespace Library.RabbitMQ.Services;
 public interface IRabbitMqService
 {
     Task PublishAsync(string exchange, string routingKey, string message);
+    void Subscribe(string queue, Func<string, Task> onMessage);
 }

--- a/src/Services/Service.ScheduleJob/Program.cs
+++ b/src/Services/Service.ScheduleJob/Program.cs
@@ -2,6 +2,8 @@ using Library.Core.Logging;
 using Library.Core.Middlewares;
 using Library.Database.Contexts.Public;
 using Library.RabbitMQ;
+using Library.RabbitMQ.Options;
+using Library.RabbitMQ.Services;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
@@ -21,6 +23,7 @@ namespace Service.ScheduleJob
             ConfigBasic(builder);
             ConfigDatabase(builder);
             ConfigQuartz(builder);
+            ConfigRabbitMq(builder);
             ConfigSerilog(builder);
             ConfigApp(builder);
         }
@@ -72,6 +75,13 @@ namespace Service.ScheduleJob
         }
 
         private static void ConfigSerilog(WebApplicationBuilder builder) => builder.UseSerilogLogging();
+
+        private static void ConfigRabbitMq(WebApplicationBuilder builder)
+        {
+            builder.Services.Configure<RabbitMqOptions>(builder.Configuration.GetSection("RabbitMq"));
+            builder.Services.AddSingleton<IRabbitMqService, RabbitMqService>();
+            builder.Services.AddHostedService<RabbitListenerHostedService>();
+        }
 
         private static void ConfigRmqEventDispatcher(WebApplication app)
         {


### PR DESCRIPTION
## Summary
- implement RabbitListenerHostedService background worker for RabbitMQ events
- add Subscribe support in RabbitMqService
- wire ScheduleJob service to listen for queue messages

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbc56c88c832a988f135a6397d2c7