### PR TITLE
Use options pattern for JWT configuration

### DIFF
--- a/src/Services/Service.Auth/Options/JwtOptions.cs
+++ b/src/Services/Service.Auth/Options/JwtOptions.cs
@@ -1,0 +1,10 @@
+namespace Service.Auth.Options;
+
+public class JwtOptions
+{
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
+    public int AccessTokenExpiresMinutes { get; set; } = 30;
+    public int RefreshTokenExpiresDays { get; set; } = 7;
+}

--- a/src/Services/Service.Auth/Program.cs
+++ b/src/Services/Service.Auth/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 
+using Service.Auth.Options;
 using Service.Auth.Services.Auth;
 using Service.Auth.Services.Jwt;
 using Service.Auth.Services.Password;
@@ -40,6 +41,9 @@ namespace Service.Auth
             builder.Services.AddScoped<IJwtService, JwtService>();
             builder.Services.AddScoped<IAuthService, AuthService>();
 
+            builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection("Jwt"));
+            JwtOptions jwtOptions = builder.Configuration.GetSection("Jwt").Get<JwtOptions>()!;
+
             builder.Services.AddAuthentication(options =>
             {
                 options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
@@ -51,9 +55,9 @@ namespace Service.Auth
                     ValidateIssuer = true,
                     ValidateAudience = true,
                     ValidateIssuerSigningKey = true,
-                    ValidIssuer = builder.Configuration["Jwt:Issuer"],
-                    ValidAudience = builder.Configuration["Jwt:Audience"],
-                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
+                    ValidIssuer = jwtOptions.Issuer,
+                    ValidAudience = jwtOptions.Audience,
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOptions.Key))
                 };
             });
         }

--- a/src/Services/Service.Auth/Services/Auth/AuthService.cs
+++ b/src/Services/Service.Auth/Services/Auth/AuthService.cs
@@ -4,13 +4,14 @@ using Library.Database.Models.Auth;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
 
 using Service.Auth.Models.Auth;
+using Service.Auth.Options;
 using Service.Auth.Services.Jwt;
 using Service.Auth.Services.Password;
 
@@ -21,9 +22,10 @@ public class AuthService(
     IPasswordHasher passwordHasher,
     IJwtService jwtService,
     ILogger<AuthService> logger,
-    IConfiguration configuration
+    IOptions<JwtOptions> jwtOptions
 ) : IAuthService
 {
+    private readonly JwtOptions _jwtOptions = jwtOptions.Value;
     public async Task<Result<UserResponse>> RegisterAsync(RegisterRequest request)
     {
         try
@@ -196,9 +198,9 @@ public class AuthService(
                 ValidateIssuer = true,
                 ValidateAudience = true,
                 ValidateIssuerSigningKey = true,
-                ValidIssuer = configuration["Jwt:Issuer"],
-                ValidAudience = configuration["Jwt:Audience"],
-                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(configuration["Jwt:Key"]!))
+                ValidIssuer = _jwtOptions.Issuer,
+                ValidAudience = _jwtOptions.Audience,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtOptions.Key))
             };
 
             JwtSecurityTokenHandler handler = new();


### PR DESCRIPTION
## Summary
- Introduce `JwtOptions` for strongly typed JWT settings
- Inject `IOptions<JwtOptions>` into JWT and auth services
- Register JWT options and configure authentication using the options

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bef7a14648832a864cba32cc243fdf