### PR TITLE
Add RabbitMQ listener to Job service

### DIFF
--- a/src/Services/Service.Job/Program.cs
+++ b/src/Services/Service.Job/Program.cs
@@ -2,12 +2,14 @@ using Library.Core.Logging;
 using Library.Core.Middlewares;
 using Library.Database.Contexts.Public;
 using Library.RabbitMQ;
+using Library.RabbitMQ.Options;
 
 using Microsoft.EntityFrameworkCore;
 
 using Quartz;
 
 using Service.Job.Jobs;
+using Service.Job.RabbitMq;
 
 namespace Service.Job;
 
@@ -20,6 +22,7 @@ internal static class Program
         ConfigBasic(builder);
         ConfigDatabase(builder);
         ConfigQuartz(builder);
+        ConfigRabbitMq(builder);
         ConfigSerilog(builder);
         ConfigApp(builder);
     }
@@ -73,6 +76,12 @@ internal static class Program
     private static void ConfigSerilog(WebApplicationBuilder builder)
     {
         builder.UseSerilogLogging();
+    }
+
+    private static void ConfigRabbitMq(WebApplicationBuilder builder)
+    {
+        builder.Services.Configure<RabbitMqOptions>(builder.Configuration.GetSection("RabbitMq"));
+        builder.Services.AddHostedService<RmqHostService>();
     }
 
     private static void ConfigRmqEventDispatcher(WebApplication app)

--- a/src/Services/Service.Job/RabbitMq/RmqHostService.cs
+++ b/src/Services/Service.Job/RabbitMq/RmqHostService.cs
@@ -1,0 +1,83 @@
+using System.Collections.Concurrent;
+
+using Library.RabbitMQ;
+using Library.RabbitMQ.Options;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using RabbitMQ.Client;
+
+namespace Service.Job.RabbitMq;
+
+/// <summary>
+///     Background service that listens to RabbitMQ queue and dispatches events to <see cref="RmqEventDispatcher" />.
+/// </summary>
+public class RmqHostService : IHostedService, IDisposable
+{
+    private readonly RabbitMqOptions _options;
+    private readonly ILogger<RmqHostService> _logger;
+
+    private IConnection? _connection;
+    private IModel? _channel;
+    private RmqReceiver? _consumer;
+
+    private static readonly ConcurrentDictionary<string, string> Messages = new();
+
+    public RmqHostService(IOptions<RabbitMqOptions> options, ILogger<RmqHostService> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        ConnectionFactory factory = new()
+        {
+            HostName = _options.HostName,
+            Port = _options.Port,
+            UserName = _options.UserName,
+            Password = _options.Password,
+            AutomaticRecoveryEnabled = true
+        };
+
+        _connection = factory.CreateConnection();
+        _channel = _connection.CreateModel();
+
+        const string exchangeName = "exchange.change_country_table";
+        const string queueName = "queue.change_country_table";
+        const string routingKey = "key.change_country_table";
+
+        _channel.ExchangeDeclare(exchangeName, ExchangeType.Topic, durable: true);
+        _channel.QueueDeclare(queueName, durable: true, exclusive: false, autoDelete: false, arguments: null);
+        _channel.QueueBind(queueName, exchangeName, routingKey);
+
+        _consumer = new RmqReceiver(_channel, _logger);
+        _channel.BasicConsume(queueName, autoAck: false, consumer: _consumer);
+
+        _logger.LogInformation("RabbitMQ listener started for queue: {Queue}", queueName);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("RabbitMQ listener stopping");
+        _channel?.Close();
+        _connection?.Close();
+        return Task.CompletedTask;
+    }
+
+    public static void AddMessage(string routingKey, string message) => Messages[routingKey] = message;
+
+    public static bool TryGetMessage(string routingKey, out string? message) => Messages.TryGetValue(routingKey, out message);
+
+    public static Task TriggerEvent(string routingKey) => RmqEventDispatcher.DispatchAsync(routingKey);
+
+    public void Dispose()
+    {
+        _channel?.Dispose();
+        _connection?.Dispose();
+    }
+}
+

--- a/src/Services/Service.Job/RabbitMq/RmqReceiver.cs
+++ b/src/Services/Service.Job/RabbitMq/RmqReceiver.cs
@@ -1,0 +1,55 @@
+using System.Text;
+
+using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace Service.Job.RabbitMq;
+
+/// <summary>
+///     Consumer that handles messages from RabbitMQ and dispatches them via <see cref="RmqHostService" />.
+/// </summary>
+public class RmqReceiver : DefaultBasicConsumer
+{
+    private readonly IModel _channel;
+    private readonly ILogger _logger;
+
+    public RmqReceiver(IModel channel, ILogger logger) : base(channel)
+    {
+        _channel = channel;
+        _logger = logger;
+    }
+
+    public override void HandleBasicDeliver(string consumerTag,
+        ulong deliveryTag,
+        bool redelivered,
+        string exchange,
+        string routingKey,
+        IBasicProperties properties,
+        ReadOnlyMemory<byte> body)
+    {
+        _logger.LogDebug("==> ExecuteAsync");
+
+        try
+        {
+            _logger.LogDebug("Consuming Message");
+            _logger.LogDebug("Message received from the exchange: {Exchange}", exchange);
+            _logger.LogDebug("Routing key: {RoutingKey}", routingKey);
+            string bodyString = Encoding.UTF8.GetString(body.ToArray());
+
+            _logger.LogInformation("Message : {Body}", bodyString);
+
+            RmqHostService.AddMessage(routingKey, bodyString);
+            _ = RmqHostService.TriggerEvent(routingKey);
+
+            _channel.BasicAck(deliveryTag, false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error handling message");
+        }
+
+        _logger.LogDebug("<== ExecuteAsync");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add hosted service that listens to RabbitMQ queue and dispatches events
- wire up RabbitMQ configuration in Job service

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf052f0394832abba0bd3bc763fb09