### PR TITLE
feat: subscribe rabbitmq with routing key

### DIFF
--- a/src/Librarys/Library.RabbitMQ/Services/IRabbitMqService.cs
+++ b/src/Librarys/Library.RabbitMQ/Services/IRabbitMqService.cs
@@ -3,4 +3,19 @@ namespace Library.RabbitMQ.Services;
 public interface IRabbitMqService
 {
     Task PublishAsync(string exchange, string routingKey, string message);
+
+    /// <summary>
+    ///     Subscribe to a queue and bind to the specified routing keys. When a message is received
+    ///     the <see cref="MessageReceived"/> event will be triggered with the routing key and message body.
+    /// </summary>
+    /// <param name="exchange">Exchange name.</param>
+    /// <param name="queue">Queue name.</param>
+    /// <param name="routingKeys">Routing keys to bind.</param>
+    void Subscribe(string exchange, string queue, params string[] routingKeys);
+
+    /// <summary>
+    ///     Event raised when a message is received from RabbitMQ.
+    ///     Parameters are routing key and message body.
+    /// </summary>
+    event Func<string, string, Task>? MessageReceived;
 }

--- a/src/Librarys/Library.RabbitMQ/Services/RabbitMqService.cs
+++ b/src/Librarys/Library.RabbitMQ/Services/RabbitMqService.cs
@@ -5,6 +5,7 @@ using Library.RabbitMQ.Options;
 using Microsoft.Extensions.Options;
 
 using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 
 namespace Library.RabbitMQ.Services;
 
@@ -13,6 +14,7 @@ public class RabbitMqService(IOptions<RabbitMqOptions> options) : IRabbitMqServi
     private readonly RabbitMqOptions _options = options.Value;
     private IConnection? _connection;
     private IModel? _channel;
+    public event Func<string, string, Task>? MessageReceived;
 
     private IModel GetOrCreateChannel()
     {
@@ -47,7 +49,29 @@ public class RabbitMqService(IOptions<RabbitMqOptions> options) : IRabbitMqServi
         return Task.CompletedTask;
     }
 
-    public void Subscribe(string queue, Action<string> onMessage) => throw new NotImplementedException();
+    public void Subscribe(string exchange, string queue, params string[] routingKeys)
+    {
+        IModel channel = GetOrCreateChannel();
+
+        channel.ExchangeDeclare(exchange, ExchangeType.Topic, durable: true);
+        channel.QueueDeclare(queue, durable: true, exclusive: false, autoDelete: false);
+        foreach (string routingKey in routingKeys)
+        {
+            channel.QueueBind(queue, exchange, routingKey);
+        }
+
+        AsyncEventingBasicConsumer consumer = new(channel);
+        consumer.Received += async (_, ea) =>
+        {
+            string message = Encoding.UTF8.GetString(ea.Body.ToArray());
+            if (MessageReceived != null)
+            {
+                await MessageReceived.Invoke(ea.RoutingKey, message);
+            }
+        };
+
+        channel.BasicConsume(queue: queue, autoAck: true, consumer: consumer);
+    }
 
     public void Dispose()
     {


### PR DESCRIPTION
## Summary
- allow RabbitMQ service to subscribe by routing key and raise events
- hook CountryUpdatedJob to RabbitMQ queue using += event registration

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfecfcb438832a93f6fe2ddc04dc08